### PR TITLE
fix: SVG use tag to use href instead of xlink:href

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The plugin will generate a spritemap to support all methods described below (fil
 </svg>
 ```
 
+By default the generated spritemap uses the `xlink:href` attribute inside the `<use>` tags for compatibility. If you want or need these generated elements to use the standard `href` attribute, you can override this by setting `output.useAttribute: 'href'`.
+
 **Img**
 
 You need to add the suffix `-view` to access the fragment.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The plugin will generate a spritemap to support all methods described below (fil
 
 ```html
 <svg>
-  <use xlink:href="/__spritemap#sprite-spiriit"></use>
+  <use href="/__spritemap#sprite-spiriit"></use>
 </svg>
 ```
 

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -61,6 +61,7 @@ export function createOptions(options: UserOptions = {}): { options: Options, lo
     name: 'spritemap.svg',
     use: true,
     view: true,
+    useAttribute: 'xlink:href',
   }
   if (options.output === false) {
     output = false
@@ -80,6 +81,10 @@ export function createOptions(options: UserOptions = {}): { options: Options, lo
         typeof options.output.view !== 'undefined'
           ? options.output.view
           : output.view,
+      useAttribute:
+        typeof options.output.useAttribute !== 'undefined'
+          ? options.output.useAttribute
+          : output.useAttribute,
     }
   }
 

--- a/src/plugins/vue.ts
+++ b/src/plugins/vue.ts
@@ -43,7 +43,7 @@ export default function CommonPlugin(shared: Shared): Plugin {
           source = `<img src="${options.route.url}#${options.prefix + svg.id}-view" ${[width, height].filter(item => item.length > 0).join(' ')}/>`
         }
         else {
-          source = `<svg><slot/><use xlink:href="${options.route.url}#${options.prefix + svg.id}"></use></svg>`
+          source = `<svg><slot/><use ${options.output.useAttribute || 'xlink:href'}="${options.route.url}#${options.prefix + svg.id}"></use></svg>`
         }
 
         const { compileTemplate } = await import('vue/compiler-sfc')

--- a/src/svgManager.ts
+++ b/src/svgManager.ts
@@ -295,7 +295,7 @@ export class SVGManager {
       // use
       if (this._options.output && this._options.output.use) {
         const use = DOM.createElement('use')
-        use.setAttribute('xlink:href', `#${this._options.prefix + svg.id}`)
+        use.setAttribute(this._options.output.useAttribute || 'xlink:href', `#${this._options.prefix + svg.id}`)
         use.setAttribute('width', svg.width.toString())
         use.setAttribute('height', svg.height.toString())
         use.setAttribute('y', y.toString())

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,6 +100,11 @@ export interface OptionsOutput {
    * @default true
    */
   view: boolean
+  /**
+   * The attribute to use for the href in the use element
+   * @default 'xlink:href'
+   */
+  useAttribute?: 'xlink:href' | 'href' | string
 }
 
 export interface OptionsStyles {


### PR DESCRIPTION
xlink:href is deprecated https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/xlink:href