### PR TITLE
docs: fix createSpritemap callback signature in styles example

### DIFF
--- a/docs/guide/customize-styles-output.md
+++ b/docs/guide/customize-styles-output.md
@@ -17,8 +17,8 @@ export default {
         filename: 'src/scss/spritemap.css',
         callback: ({ content, options, createSpritemap }) => {
           let insert = ''
-          insert += createSpritemap((name, svg) => {
-            const selector = `.${options.prefix}${name}`
+          insert += createSpritemap((svg) => {
+            const selector = `.${options.prefix}${svg.id}`
             let sprite = ''
             sprite = `${selector} {`
             sprite += `\n\tbackground: url("${svg.svgDataUri}") center no-repeat;`


### PR DESCRIPTION
The advanced styles-customization example in `docs/guide/customize-styles-output.md` calls `createSpritemap((name, svg) => ...)`, but the actual signature is `(svg: SvgDataUriMapObject, isLast: boolean) => string` (`src/core/styles.ts:52-60`). Copy-pasting the example produces selectors like `.sprite-[object Object]` and reads `.svgDataUri` off a boolean.

This corrects the example to use `svg.id` for the selector (`SvgDataUriMapObject` fields per `src/types.ts:28-34`); the unused `isLast` parameter is omitted from the example for brevity.

Closes #113